### PR TITLE
Disallow transferring Liquidity Tokens to Exchange contract

### DIFF
--- a/contracts/uniswap_exchange.vy
+++ b/contracts/uniswap_exchange.vy
@@ -471,6 +471,7 @@ def balanceOf(_owner : address) -> uint256:
 
 @public
 def transfer(_to : address, _value : uint256) -> bool:
+    assert _to != self
     self.balances[msg.sender] -= _value
     self.balances[_to] += _value
     log.Transfer(msg.sender, _to, _value)
@@ -478,6 +479,7 @@ def transfer(_to : address, _value : uint256) -> bool:
 
 @public
 def transferFrom(_from : address, _to : address, _value : uint256) -> bool:
+    assert _to != self
     self.balances[_from] -= _value
     self.balances[_to] += _value
     self.allowances[_from][msg.sender] -= _value


### PR DESCRIPTION
If someone has been tricked or accidentally transfers UniSwap liquidity tokens to  the Exchange contract, he will lose his liquidity funds.
I would suggest that transfer(...) and transferFrom(...) function implementations disallow the exchange contract receiving the liquidity Tokens.

Another solution could be to call removeLiquidity if ```_to == self```, but maybe it is better to be more explicit (and less code).